### PR TITLE
relax dependency for activesupport

### DIFF
--- a/ecs_autoscaling_scheduler.gemspec
+++ b/ecs_autoscaling_scheduler.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-applicationautoscaling", "~> 1.62"
   spec.add_dependency "aws-sdk-ecs", "~> 1.100"
   spec.add_dependency "tty-prompt", "~> 0.23"
-  spec.add_dependency "activesupport", "~> 6.1"
+  spec.add_dependency "activesupport", "> 6.1"
   spec.add_development_dependency "rubocop-rails_config"
 
   # For more information and examples about making a new gem, checkout our


### PR DESCRIPTION
Currently it depends on activesupport v6 series but it's not necessary.